### PR TITLE
Fixes #4, IPv6 AgentIP being unpacked to sFlowSample when sFlowDatagram is requested

### DIFF
--- a/sFlow.pm
+++ b/sFlow.pm
@@ -995,7 +995,7 @@ sub _decodeIpAddress {
 
     elsif ($IpVersion == IPv6) {
 
-      $sFlowSample->{$keyName} =
+      $sFlowDatagram->{$keyName} =
         join(':', unpack("x$offset H4H4H4H4H4H4H4H4", $sFlowDatagramPacked));
 
       $offset += 16;


### PR DESCRIPTION
Proposed fix for issue #4, IPv6 AgentIP is being unpacked and written into sFlowSample when sFlowDatagram is being requsted