### PR TITLE
Fix bugs in `_decodeIPv6Data()` and `_decodeNatData()`

### DIFF
--- a/lib/Net/sFlow.pm
+++ b/lib/Net/sFlow.pm
@@ -1636,23 +1636,16 @@ sub _decodeIPv6Data {
 
   $sFlowSample->{IPv6DATA} = 'IPv6DATA';
 
-  (undef,
-   $sFlowSample->{IPv6Packetlength},
-   $sFlowSample->{IPv6NextHeaderProto}) =
-    unpack("a$offset N2", $sFlowDatagramPacked);
-
-  $sFlowSample->{IPv6srcIp} =
-    join(':', unpack("x$offset H4H4H4H4H4H4H4H4", $sFlowDatagramPacked));
-
-  $sFlowSample->{IPv6destIp} =
-    join(':', unpack("x$offset H4H4H4H4H4H4H4H4", $sFlowDatagramPacked));
-
-  (undef,
-   $sFlowSample->{IPv6srcPort},
-   $sFlowSample->{IPv6destPort},
-   $sFlowSample->{IPv6tcpFlags},
-   $sFlowSample->{IPv6Priority}) =
-    unpack("a$offset N4", $sFlowDatagramPacked);
+  (
+    $sFlowSample->{IPv6Packetlength},
+    $sFlowSample->{IPv6NextHeaderProto},
+    $sFlowSample->{IPv6srcIp},
+    $sFlowSample->{IPv6destIp},
+    $sFlowSample->{IPv6srcPort},
+    $sFlowSample->{IPv6destPort},
+    $sFlowSample->{IPv6tcpFlags},
+    $sFlowSample->{IPv6Priority}
+  ) = unpack("a$offset N2 a16 a16 N4", $sFlowDatagramPacked);
 
   $offset += 56;
   $$offsetref = $offset;

--- a/lib/Net/sFlow.pm
+++ b/lib/Net/sFlow.pm
@@ -2303,7 +2303,7 @@ sub _decodeNatData {
       $sFlowSample,
       $sFlowSamples,
       $sFlowSample->{NatIpVersionSrcAddress},
-      'NatIpVersionSrcAddress',
+      'NatSrcAddress',
       undef,
     );
 
@@ -2325,7 +2325,7 @@ sub _decodeNatData {
       $sFlowSample,
       $sFlowSamples,
       $sFlowSample->{NatIpVersionDestAddress},
-      'NatIpVersionDestAddress',
+      'NatDestAddress',
       undef,
     );
 


### PR DESCRIPTION
This PR contains two bug fixes:

 * `_decodeIPv6Data()` is using the same data for consecutive `unpack()` operations, resulting in garbage data.
 * `_decodeNatData()` is storing the source and destination IP addresses in the _version_ fields (thereby overwriting them).

For more details see the `git log`.